### PR TITLE
Fixed tmux DLE header in ZRINIT

### DIFF
--- a/ChangeLog
+++ b/ChangeLog
@@ -1,3 +1,7 @@
+2018-02-23	Gareth <gbjk@theermeon.com>
+
+	* Fix tmux DLE header in ZRINIT for rz
+
 1998-06-15	Uwe Ohse  <uwe@ohse.de>
 
 	* src/rbsb.c (io_mode), case 1:


### PR DESCRIPTION
tmux isn't compatible with rz because it requires a dle header wrapper.
We can't prefix/postfix it because the <esc> \ comes after the ZRINIT
before the file receive

Fixes thermeon/go-carsplus-login#280